### PR TITLE
Update yolo.py

### DIFF
--- a/yolo.py
+++ b/yolo.py
@@ -365,7 +365,7 @@ class YoloBody(nn.Module):
 
         # 20, 20, 1024 => 20, 20, 512
         self.sppcspc                = SPPCSPC(transition_channels * 32, transition_channels * 16)
-        self.cbam1                  = CBAM(transition_channels * 16)
+        # self.cbam1                  = CBAM(transition_channels * 16)
         # 20, 20, 512 => 20, 20, 256 => 40, 40, 256
         self.conv_for_P5            = Conv(transition_channels * 16, transition_channels * 8)
         # 40, 40, 1024 => 40, 40, 256
@@ -373,11 +373,11 @@ class YoloBody(nn.Module):
         # 40, 40, 512 => 40, 40, 256
         self.conv3_for_upsample1    = Multi_Concat_Block(transition_channels * 16, panet_channels * 4, transition_channels * 8, e=e, n=n, ids=ids)
 
-        self.cbam2 = CBAM(transition_channels * 32)
+        # self.cbam2 = CBAM(transition_channels * 32)
         # 40, 40, 256 => 40, 40, 128 => 80, 80, 128
         self.conv_for_P4            = Conv(transition_channels * 8, transition_channels * 4)
         # 80, 80, 512 => 80, 80, 128
-        self.cbam3 = CBAM(transition_channels * 16)
+        # self.cbam3 = CBAM(transition_channels * 16)
         self.conv_for_feat1         = Conv(transition_channels * 16, transition_channels * 4)
         # 80, 80, 256 => 80, 80, 128
         self.conv3_for_upsample2    = Multi_Concat_Block(transition_channels * 8, panet_channels * 2, transition_channels * 4, e=e, n=n, ids=ids)
@@ -486,5 +486,5 @@ class YoloBody(nn.Module):
         #---------------------------------------------------#
         out0 = self.yolo_head_P5(P5)
         # outputs = self.head.forward((P3, P4, P5))
-        return [out0, out1, out2]
+        return [out0, out1]
         # return outputs

--- a/yolo.py
+++ b/yolo.py
@@ -365,7 +365,7 @@ class YoloBody(nn.Module):
 
         # 20, 20, 1024 => 20, 20, 512
         self.sppcspc                = SPPCSPC(transition_channels * 32, transition_channels * 16)
-        # self.cbam1                  = CBAM(transition_channels * 16)
+        self.cbam1                  = CBAM(transition_channels * 16)
         # 20, 20, 512 => 20, 20, 256 => 40, 40, 256
         self.conv_for_P5            = Conv(transition_channels * 16, transition_channels * 8)
         # 40, 40, 1024 => 40, 40, 256
@@ -373,11 +373,11 @@ class YoloBody(nn.Module):
         # 40, 40, 512 => 40, 40, 256
         self.conv3_for_upsample1    = Multi_Concat_Block(transition_channels * 16, panet_channels * 4, transition_channels * 8, e=e, n=n, ids=ids)
 
-        # self.cbam2 = CBAM(transition_channels * 32)
+        self.cbam2 = CBAM(transition_channels * 32)
         # 40, 40, 256 => 40, 40, 128 => 80, 80, 128
         self.conv_for_P4            = Conv(transition_channels * 8, transition_channels * 4)
         # 80, 80, 512 => 80, 80, 128
-        # self.cbam3 = CBAM(transition_channels * 16)
+        self.cbam3 = CBAM(transition_channels * 16)
         self.conv_for_feat1         = Conv(transition_channels * 16, transition_channels * 4)
         # 80, 80, 256 => 80, 80, 128
         self.conv3_for_upsample2    = Multi_Concat_Block(transition_channels * 8, panet_channels * 2, transition_channels * 4, e=e, n=n, ids=ids)

--- a/yolo_training.py
+++ b/yolo_training.py
@@ -88,8 +88,8 @@ class YOLOLoss(nn.Module):
         # else:  # transform from xywh to xyxy
         #     b1_x1, b1_x2 = box1[0] - box1[2] / 2, box1[0] + box1[2] / 2
         #     b1_y1, b1_y2 = box1[1] - box1[3] / 2, box1[1] + box1[3] / 2
-        #     b2_x1, b2_x2 = box2[0] - box2[2] / 2, box2[0] + box2[2] / 2
-        #     b2_y1, b2_y2 = box2[1] - box2[3] / 2, box2[1] + box2[3] / 2
+            b2_x1, b2_x2 = box2[0] - box2[2] / 2, box2[0] + box2[2] / 2
+            b2_y1, b2_y2 = box2[1] - box2[3] / 2, box2[1] + box2[3] / 2
 
         # Intersection area
         inter = (torch.min(b1_x2, b2_x2) - torch.max(b1_x1, b2_x1)).clamp(0) * \

--- a/yolo_training.py
+++ b/yolo_training.py
@@ -77,7 +77,7 @@ class YOLOLoss(nn.Module):
     #     else:
     #         return iou  # IoU
 
-    def bbox_iou(self, box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False, SIoU=False, EIoU=False, eps=1e-7):
+    def bbox_iou(self, box1, box2, x1y1x2y2=True, GIoU=True, DIoU=False, CIoU=False, SIoU=False, EIoU=False, eps=1e-7):
         # Returns the IoU of box1 to box2. box1 is 4, box2 is nx4
         box2 = box2.T
 
@@ -85,11 +85,11 @@ class YOLOLoss(nn.Module):
         if x1y1x2y2:  # x1, y1, x2, y2 = box1
             b1_x1, b1_y1, b1_x2, b1_y2 = box1[0], box1[1], box1[2], box1[3]
             b2_x1, b2_y1, b2_x2, b2_y2 = box2[0], box2[1], box2[2], box2[3]
-        else:  # transform from xywh to xyxy
-            b1_x1, b1_x2 = box1[0] - box1[2] / 2, box1[0] + box1[2] / 2
-            b1_y1, b1_y2 = box1[1] - box1[3] / 2, box1[1] + box1[3] / 2
-            b2_x1, b2_x2 = box2[0] - box2[2] / 2, box2[0] + box2[2] / 2
-            b2_y1, b2_y2 = box2[1] - box2[3] / 2, box2[1] + box2[3] / 2
+        # else:  # transform from xywh to xyxy
+        #     b1_x1, b1_x2 = box1[0] - box1[2] / 2, box1[0] + box1[2] / 2
+        #     b1_y1, b1_y2 = box1[1] - box1[3] / 2, box1[1] + box1[3] / 2
+        #     b2_x1, b2_x2 = box2[0] - box2[2] / 2, box2[0] + box2[2] / 2
+        #     b2_y1, b2_y2 = box2[1] - box2[3] / 2, box2[1] + box2[3] / 2
 
         # Intersection area
         inter = (torch.min(b1_x2, b2_x2) - torch.max(b1_x1, b2_x1)).clamp(0) * \


### PR DESCRIPTION
取消cbam模块、输出的out2关闭

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Model inference now returns two outputs instead of three; update workflows or integrations that relied on the removed output.
  * Public interfaces remain unchanged, but consumers should verify compatibility.

* **Bug Fix / Behavior Change**
  * Default IoU calculation switched to GIoU, altering loss/metric behavior.
  * An automatic coordinate-conversion path is disabled, which may cause runtime errors for callers relying on it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->